### PR TITLE
Fix Android build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+* Fix Android build.
+
 ## 1.1.1
 
 * **Breaking change**: Renamed `InAppUpdateState` to `AppUpdateInfo` to mirror the Android SDK and

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,4 +42,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.google.android.play:core:1.6.3'
+    implementation project(':flutter_plugin_android_lifecycle')
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'in_app_update'
+include ':flutter_plugin_android_lifecycle'

--- a/android/src/main/kotlin/de/ffuf/in_app_update/InAppUpdatePlugin.kt
+++ b/android/src/main/kotlin/de/ffuf/in_app_update/InAppUpdatePlugin.kt
@@ -67,16 +67,16 @@ class InAppUpdatePlugin(private val activity: Activity) : MethodCallHandler,
 
 
   override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    val lifecycle = FlutterLifecycleAdapter.getLifecycle(binding)
+    val lifecycle: Lifecycle? = FlutterLifecycleAdapter.getLifecycle(binding)
     lifecycleObserver = CustomObserver()
 
-    lifecycle.addObserver(lifecycleObserver!!)
+    lifecycle?.addObserver(lifecycleObserver!!)
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    val lifecycle = FlutterLifecycleAdapter.getLifecycle(binding)
+    val lifecycle: Lifecycle? = FlutterLifecycleAdapter.getLifecycle(binding)
 
-    if (lifecycleObserver != null) lifecycle.removeObserver(lifecycleObserver!!)
+    if (lifecycleObserver != null) lifecycle?.removeObserver(lifecycleObserver!!)
   }
 
   override fun onMethodCall(call: MethodCall, result: Result) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_update
 description: Enables In App Updates on Android using the official Android APIs.
-version: 1.1.1
+version: 1.1.2
 authors:
 - FFUF <info@ffuf.de>
 - Jonas Bark <jonas.bark@ffuf.de>


### PR DESCRIPTION
Sorry, the [`flutter_plugin_android_lifecycle`](https://pub.dev/packages/flutter_plugin_android_lifecycle) documentation is not good. This implementation definitely works in the plugin module itself, but I will have to test it as a dependency.

@jonasbark 