### PR TITLE
Migrate plugin and example to null safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/
 !**/.idea/runConfigurations/
 !**/.idea/runConfigurations/*
 
+example/pubspec.lock
+pubspec.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 1.1.16
+## 2.0.0
+
+* Migrated to null safety (#60)
+* __Breaking__: Replaced `updateAvailable` with `updateAvailability`.
 * Expose more fields to access, added `updateAvailability`, `installStatus`, `clientVersionStalenessDays` and `updatePriority`. (#40)
 * Introduce `UpdateAvailability`  and `InstallStatus` for constants.
-* Deprecate `updateAvailable` and replace with `updateAvailability` instead.
 
 ## 1.1.15
 * fix android Gradle version (6.5.+) build error (#55). thanks for https://github.com/mig35

--- a/android/src/main/kotlin/de/ffuf/in_app_update/InAppUpdatePlugin.kt
+++ b/android/src/main/kotlin/de/ffuf/in_app_update/InAppUpdatePlugin.kt
@@ -214,10 +214,10 @@ class InAppUpdatePlugin : FlutterPlugin, MethodCallHandler,
                     "updateAvailability" to info.updateAvailability(),
                     "immediateAllowed" to info.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE),
                     "flexibleAllowed" to info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE),
-                    "availableVersionCode" to info.availableVersionCode(),
+                    "availableVersionCode" to info.availableVersionCode(), //Nullable according to docs
                     "installStatus" to info.installStatus(),
                     "packageName" to info.packageName(),
-                    "clientVersionStalenessDays" to info.clientVersionStalenessDays(),
+                    "clientVersionStalenessDays" to info.clientVersionStalenessDays(), //Nullable according to docs
                     "updatePriority" to info.updatePriority()
                   )
             )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,7 +11,8 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  AppUpdateInfo _updateInfo;
+
+  AppUpdateInfo? _updateInfo;
 
   GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey();
 
@@ -28,13 +29,15 @@ class _MyAppState extends State<MyApp> {
       setState(() {
         _updateInfo = info;
       });
-    }).catchError((e) => _showError(e));
+    }).catchError((e) => showSnack(e.toString())); 
   }
-
-  void _showError(dynamic exception) {
-    _scaffoldKey.currentState.showSnackBar(
-      SnackBar(content: Text(exception.toString())),
-    );
+  
+  void showSnack (String text) {
+    if(_scaffoldKey.currentContext != null) {
+      ScaffoldMessenger.of(_scaffoldKey.currentContext!).showSnackBar(
+          SnackBar(content: Text(text))
+      );
+    }
   }
 
   @override
@@ -52,21 +55,21 @@ class _MyAppState extends State<MyApp> {
               Center(
                 child: Text('Update info: $_updateInfo'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: Text('Check for Update'),
                 onPressed: () => checkForUpdate(),
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: Text('Perform immediate update'),
                 onPressed: _updateInfo?.updateAvailability ==
                         UpdateAvailability.updateAvailable
                     ? () {
                         InAppUpdate.performImmediateUpdate()
-                            .catchError((e) => _showError(e));
+                            .catchError((e) => showSnack(e.toString()));
                       }
                     : null,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: Text('Start flexible update'),
                 onPressed: _updateInfo?.updateAvailability ==
                         UpdateAvailability.updateAvailable
@@ -75,20 +78,18 @@ class _MyAppState extends State<MyApp> {
                           setState(() {
                             _flexibleUpdateAvailable = true;
                           });
-                        }).catchError((e) => _showError(e));
+                        }).catchError((e) => showSnack(e.toString()));
                       }
                     : null,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: Text('Complete flexible update'),
                 onPressed: !_flexibleUpdateAvailable
                     ? null
                     : () {
                         InAppUpdate.completeFlexibleUpdate().then((_) {
-                          _scaffoldKey.currentState.showSnackBar(
-                            SnackBar(content: Text('Success!')),
-                          );
-                        }).catchError((e) => _showError(e));
+                          showSnack("Success!");
+                        }).catchError((e) => showSnack(e.toString()));
                       },
               )
             ],

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the in_app_update plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the in_app_update plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/lib/in_app_update.dart
+++ b/lib/in_app_update.dart
@@ -35,7 +35,6 @@ class InAppUpdate {
     final result = await _channel.invokeMethod('checkForUpdate');
 
     return AppUpdateInfo(
-      result['updateAvailability'] == UpdateAvailability.updateAvailable,
       result['updateAvailability'],
       result['immediateAllowed'],
       result['flexibleAllowed'],
@@ -73,18 +72,15 @@ class InAppUpdate {
 }
 
 class AppUpdateInfo {
-  @Deprecated('Use updateAvailability instead.')
-  final bool updateAvailable;
+  final int updateAvailability;
   final bool immediateUpdateAllowed, flexibleUpdateAllowed;
-  final int updateAvailability,
-      availableVersionCode,
-      installStatus,
-      clientVersionStalenessDays,
-      updatePriority;
+  final int? availableVersionCode;
+  final int installStatus;
   final String packageName;
+  final int updatePriority;
+  final int? clientVersionStalenessDays;
 
   AppUpdateInfo(
-    this.updateAvailable,
     this.updateAvailability,
     this.immediateUpdateAllowed,
     this.flexibleUpdateAllowed,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: in_app_update
 description: Enables In App Updates on Android using the official Android APIs.
-version: 1.1.16
+version: 2.0.0
 author: jonas.bark@ffuf.de
 homepage: https://ffuf.de
 repository: https://github.com/feilfeilundfeil/flutter_in_app_update
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.20.0 <2.0.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://ffuf.de
 repository: https://github.com/feilfeilundfeil/flutter_in_app_update
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0 <2.0.0"
 
 dependencies:


### PR DESCRIPTION
closes #60 

This converts the master branch and example to null safety following the Android docs on AppUpdateInfo nullability.

I do not know how stable main is so there might need to be more changes before release to make this a stable migration. I tested the example app and got the expected error with a development build so everything seems to be working ok.

I also converted the deprecation to a full api change because this is a major version (has to be released as 2.0.0) might as well just make the breaking change.

`@Deprecated('Use updateAvailability instead.')
  final bool updateAvailable;`